### PR TITLE
Polish: badges, runtime deps, manifest, docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@ This page summarises the primary extension points for building strategies and to
 
 - `run_from_config(path: str) -> dict`
   - Loads a YAML config, resolves paths, executes the backtest, and returns a manifest-style dictionary containing artifact paths.
-- `prepare_artifacts_dir(cfg_path: Path, config: dict) -> tuple[str, Path]`
+- `prepare_artifacts_dir(cfg_path: Path, config: dict, run_id: str | None = None) -> tuple[str, Path]`
   - Allocates an isolated `artifacts/<run_id>` directory for each run.
 
 ## Engine (`microalpha.engine.Engine`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,12 @@ authors = [
     { name = "Mateo Bodon", email = "mateo.bodon@yale.edu" },
 ]
 requires-python = ">=3.9"
-dependencies = ["numpy", "pandas", "pyyaml"]
+dependencies = [
+    "numpy",
+    "pandas",
+    "pyyaml",
+    "pydantic>=2",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/microalpha/manifest.py
+++ b/src/microalpha/manifest.py
@@ -10,36 +10,32 @@ import random
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from typing import Optional
 
 import numpy as np
+
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas is a required runtime dep
+    pd = None  # type: ignore[assignment]
 
 
 @dataclass
 class Manifest:
     run_id: str
     git_sha: str
+    microalpha_version: str
     python: str
     platform: str
-    microalpha_version: str
+    numpy_version: str
+    pandas_version: str
     seed: int
-    config_path: str
     config_sha256: str
 
 
-def build(
-    seed: Optional[int],
-    config_path: str,
-    run_id: str,
-    config_sha256: str,
-) -> Manifest:
-    """Construct a manifest and synchronise global RNG state."""
-
-    if seed is None:
-        seed = random.randint(0, 2**32 - 1)
-
-    random.seed(seed)
-    np.random.seed(seed)
+def resolve_git_sha() -> str:
+    """Return the current Git SHA or ``"unknown"`` when unavailable."""
 
     try:
         sha = (
@@ -49,23 +45,80 @@ def build(
             .decode()
             .strip()
         )
-    except Exception:
+    except Exception:  # pragma: no cover - exercised when Git missing
         sha = "unknown"
+    return sha
 
+
+def _short_sha(git_sha: str) -> str:
+    if not git_sha or git_sha == "unknown":
+        return "nogit"
+    return git_sha[:7]
+
+
+def generate_run_id(git_sha: str, timestamp: Optional[datetime] = None) -> str:
+    """Create a run identifier combining UTC timestamp and short SHA."""
+
+    ts = (timestamp or datetime.utcnow()).strftime("%Y-%m-%dT%H-%M-%SZ")
+    return f"{ts}-{_short_sha(git_sha)}"
+
+
+def _resolve_version(distribution: str, fallback: Optional[str] = None) -> str:
     try:
-        version = importlib_metadata.version("microalpha")
+        return importlib_metadata.version(distribution)
     except importlib_metadata.PackageNotFoundError:
-        version = "unknown"
+        return fallback or "unknown"
+
+
+def _resolve_microalpha_version() -> str:
+    packages = importlib_metadata.packages_distributions().get("microalpha", [])
+    for dist_name in packages:
+        version = _resolve_version(dist_name)
+        if version != "unknown":
+            return version
+    return _resolve_version("microalpha")
+
+
+def _numpy_version() -> str:
+    return _resolve_version("numpy", getattr(np, "__version__", None))
+
+
+def _pandas_version() -> str:
+    version = _resolve_version("pandas")
+    if version != "unknown":
+        return version
+    if pd is not None:
+        return getattr(pd, "__version__", "unknown")
+    return "unknown"
+
+
+def build(
+    seed: Optional[int],
+    config_sha256: str,
+    git_sha: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> Manifest:
+    """Construct a manifest and synchronise global RNG state."""
+
+    if seed is None:
+        seed = random.randint(0, 2**32 - 1)
+
+    random.seed(seed)
+    np.random.seed(seed)
+
+    resolved_git_sha = git_sha or resolve_git_sha()
+    resolved_run_id = run_id or generate_run_id(resolved_git_sha)
 
     return Manifest(
-        run_id,
-        sha,
-        sys.version,
-        platform.platform(),
-        version,
-        seed,
-        os.path.abspath(config_path),
-        config_sha256,
+        run_id=resolved_run_id,
+        git_sha=resolved_git_sha,
+        microalpha_version=_resolve_microalpha_version(),
+        python=sys.version,
+        platform=platform.platform(),
+        numpy_version=_numpy_version(),
+        pandas_version=_pandas_version(),
+        seed=seed,
+        config_sha256=config_sha256,
     )
 
 

--- a/tests/test_manifest_written.py
+++ b/tests/test_manifest_written.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from microalpha.config import BacktestCfg, ExecModelCfg, StrategyCfg
+from microalpha.config_wfv import WalkForwardWindow, WFVCfg
+from microalpha.runner import run_from_config
+from microalpha.walkforward import run_walk_forward
+
+
+def _write_price_series(directory: Path, periods: int = 10) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    dates = pd.date_range("2025-01-01", periods=periods, freq="D")
+    df = pd.DataFrame({"close": [100 + i for i in range(periods)]}, index=dates)
+    df.to_csv(directory / "SPY.csv")
+
+
+def _backtest_config(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "run_data"
+    _write_price_series(data_dir, periods=8)
+
+    config = {
+        "data_path": str(data_dir),
+        "symbol": "SPY",
+        "cash": 50_000.0,
+        "seed": 21,
+        "exec": {"type": "instant"},
+        "strategy": {
+            "name": "MeanReversionStrategy",
+            "params": {"lookback": 2, "z_threshold": 0.5},
+        },
+        "artifacts_dir": str(tmp_path / "run_artifacts"),
+    }
+
+    cfg_path = tmp_path / "run_config.yaml"
+    cfg_path.write_text(yaml.safe_dump(config))
+    return cfg_path
+
+
+def _walkforward_config(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "wfv_data"
+    _write_price_series(data_dir, periods=16)
+
+    config = WFVCfg(
+        template=BacktestCfg(
+            data_path=str(data_dir),
+            symbol="SPY",
+            cash=75_000.0,
+            seed=11,
+            exec=ExecModelCfg(type="instant"),
+            strategy=StrategyCfg(
+                name="MeanReversionStrategy",
+                params={"lookback": 2, "z": 0.5},
+            ),
+        ),
+        walkforward=WalkForwardWindow(
+            start="2025-01-01",
+            end="2025-01-16",
+            training_days=6,
+            testing_days=3,
+        ),
+        grid={"lookback": [2, 3], "z": [0.5, 1.0]},
+        artifacts_dir=str(tmp_path / "wfv_artifacts"),
+    )
+
+    cfg_path = tmp_path / "wfv_config.yaml"
+    cfg_path.write_text(yaml.safe_dump(config.model_dump(mode="json")))
+    return cfg_path
+
+
+def test_run_and_walkforward_emit_manifests_and_metrics(tmp_path: Path) -> None:
+    run_cfg = _backtest_config(tmp_path)
+    run_result = run_from_config(str(run_cfg))
+    run_dir = Path(run_result["artifacts_dir"])
+
+    assert (run_dir / "manifest.json").is_file()
+    assert (run_dir / "metrics.json").is_file()
+    assert (run_dir / "equity_curve.csv").is_file()
+
+    wfv_cfg = _walkforward_config(tmp_path)
+    wfv_result = run_walk_forward(str(wfv_cfg))
+    wfv_dir = Path(wfv_result["artifacts_dir"])
+
+    assert (wfv_dir / "manifest.json").is_file()
+    assert (wfv_dir / "metrics.json").is_file()
+    assert (wfv_dir / "equity_curve.csv").is_file()

--- a/tests/test_metrics_invariant.py
+++ b/tests/test_metrics_invariant.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from microalpha.runner import run_from_config
+
+
+def _make_config(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    dates = pd.date_range("2025-01-01", periods=6, freq="D")
+    df = pd.DataFrame({"close": [100, 101, 99, 102, 98, 103]}, index=dates)
+    df.to_csv(data_dir / "SPY.csv")
+
+    config = {
+        "data_path": str(data_dir),
+        "symbol": "SPY",
+        "cash": 100_000.0,
+        "seed": 13,
+        "exec": {"type": "twap", "slices": 2},
+        "strategy": {
+            "name": "MeanReversionStrategy",
+            "params": {"lookback": 2, "z_threshold": 0.5},
+        },
+        "artifacts_dir": str(tmp_path / "artifacts"),
+    }
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(config))
+    return cfg_path
+
+
+def test_metrics_are_run_invariant(tmp_path: Path) -> None:
+    cfg_path = _make_config(tmp_path)
+
+    first = run_from_config(str(cfg_path))
+    second = run_from_config(str(cfg_path))
+
+    first_metrics = Path(first["artifacts_dir"]) / "metrics.json"
+    second_metrics = Path(second["artifacts_dir"]) / "metrics.json"
+
+    assert first_metrics.read_bytes() == second_metrics.read_bytes()


### PR DESCRIPTION
## Summary
- update README badges, requirements, artifact documentation, and development/profiling notes
- declare `pydantic>=2` as a runtime dependency and surface it in project metadata
- guarantee manifest and metrics artifacts for run and walk-forward flows with deterministic metrics tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e18be8524c8324b61e6d982024d6f2