### PR TITLE
docs: remove unsafe Pages install route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # microalpha
 
-[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-0969da)](https://mateobodon.github.io/microalpha/)
-
 **A leakage-aware, event-driven research engine for turning quantitative ideas
 into timestamped, costed, reproducible evidence.**
 


### PR DESCRIPTION
Emergency containment for the independent portfolio audit.

- removes the README link to the current GitHub Pages site
- the site currently recommends `pip install microalpha`, which resolves to an unrelated PyPI project
- repository homepage metadata has already been cleared

The docs link will only be restored after the site uses source installation from this repository and the corrected deployment is verified publicly.