### PR TITLE
docs: restore verified site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # microalpha
 
+[![Documentation](https://img.shields.io/badge/docs-live-2563eb)](https://mateobodon.github.io/microalpha/)
+
 **A leakage-aware, event-driven research engine for turning quantitative ideas
 into timestamped, costed, reproducible evidence.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,8 @@ Microalpha is an event-driven research platform for reproducible quantitative st
    pip install -e ".[dev]"
    ```
 
-   > Do not use `pip install microalpha`: that PyPI name belongs to an
-   > unrelated third-party project. This repository has no public package
-   > release; the supported installation path is the source checkout above.
+   > The namesake package on PyPI is an unrelated third-party project. This
+   > repository has no public package release; use the source checkout above.
 
 2. **Run the bundled mean-reversion backtest**
 

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -9,8 +9,8 @@ def test_public_install_and_artifact_links_are_safe() -> None:
 
     assert "git clone https://github.com/MateoBodon/microalpha.git" in readme
     assert "git clone https://github.com/MateoBodon/microalpha.git" in docs_home
-    assert "Do not use `pip install microalpha`" in docs_home
-    assert "\n   pip install microalpha\n" not in docs_home
+    assert "namesake package on PyPI is an unrelated third-party project" in docs_home
+    assert "pip install microalpha" not in docs_home
 
     for rel_path in ("artifacts/sample_flagship", "artifacts/sample_wfv"):
         assert rel_path in readme


### PR DESCRIPTION
## Summary
- restore the documentation link now that the live Pages site has been verified
- remove the unsafe PyPI command entirely, including from warning text
- keep a regression test that rejects that command

## Verification
- `PYTHONPATH=src pytest -q tests/test_docs_links.py` (1 passed)
- live Pages inspection confirmed source-checkout installation and unrelated-package warning before this follow-up